### PR TITLE
フロントエンドとの認可連携実装

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# デフォルトの無視対象ファイル
+/shelf/
+/workspace.xml
+# エディターベースの HTTP クライアントリクエスト
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.32/17d46b3e205515e1e8efd3ee4d57ce8018914163/lombok-1.18.32.jar" />
+        </processorPath>
+        <module name="MyEnglishServer.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/MyEnglishServer" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/MyEnglishServer" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://repo.spring.io/snapshot" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/MyEnglishServer" />
+  </component>
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/MyEnglishServer.main.iml" filepath="$PROJECT_DIR$/.idea/modules/MyEnglishServer.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/myEnglish.server.iml" filepath="$PROJECT_DIR$/.idea/myEnglish.server.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/MyEnglishServer.main.iml
+++ b/.idea/modules/MyEnglishServer.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../MyEnglishServer/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../MyEnglishServer/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/.idea/myEnglish.server.iml
+++ b/.idea/myEnglish.server.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/MyEnglishServer/build.gradle
+++ b/MyEnglishServer/build.gradle
@@ -39,9 +39,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	//OAUTH
+	// OAUTH
 	implementation 'org.springframework.security:spring-security-oauth2-client'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/MyEnglishServer/src/main/java/myenglish/security/OAuth2LoginSecurityConfig.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/OAuth2LoginSecurityConfig.java
@@ -15,14 +15,15 @@ public class OAuth2LoginSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/login/**").permitAll() // login配下は認証不要
                         .anyRequest().authenticated()
                 )
-                .oauth2Login(withDefaults())
-
+                .csrf(csrf -> csrf.disable()) // CSRFを無効化
+                .oauth2Login(withDefaults())  // 認証設定にデフォルトの設定を利用する (applicatin.yml)
                 .oauth2Login(customizer -> customizer
-                        .defaultSuccessUrl("/loginsuccess",true));
-
+                        .defaultSuccessUrl("/loginsuccess",true)); // ログイン成功後にログイン成功リダイレクト先に遷移。trueでいつでも有効にする。
 
         return http.build();
     }
+
 }

--- a/MyEnglishServer/src/main/java/myenglish/security/OAuth2LoginSecurityConfig.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/OAuth2LoginSecurityConfig.java
@@ -11,14 +11,18 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .anyRequest().authenticated()
                 )
-                .oauth2Login(withDefaults());
+                .oauth2Login(withDefaults())
+
+                .oauth2Login(customizer -> customizer
+                        .defaultSuccessUrl("/loginsuccess",true));
+
+
         return http.build();
     }
 }

--- a/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
@@ -1,21 +1,46 @@
 package myenglish.security;
 
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.jsonwebtoken.Jwts;
 
+import java.io.IOException;
+import java.util.Date;
 import java.util.logging.Logger;
 
 /*認証成功時にJWT-Tokenを発行する*/
 @RestController
 public class OAuthSuccessController {
     Logger logger = Logger.getLogger(OAuthSuccessController.class.getName());
+    String JWT_SECRET = "e976d54cca0ba5f9744a6d4f8c3ee37c05081d204201740c469e6456e5f3eda3d6cd47bac68c9d05e5c2274baa623e8a977764c9aebd60ae4bd7ae4006dd0040f3ac25bf6f4a165b6f20c020529d3bece4ff60f9d444ba6bb59bfe2b47aa7eb63ee396fb005067ffb7f4bd2a1f2de66b966080a364433bda63b40e96ad15a38cf17f8dc36bb2a9d3517ef3ead06e364447755bf89a94eaecb63967669cca5b7bf317a1f075e1d97dc2348b928fd941debfd03adec6ca45fcb35e5039a4f486bdb63dd00ee2b2dccf76786f4925c59653b269308cec7c271f78ca21165e7bda8664353d8fee95dc4886f79d4fda139d9a4fe80afe9edc52356f13803e60533bf4";
+
     @GetMapping("/loginsuccess")
-    public void loginSuccess(Authentication authentication) {
+    public String loginSuccess(Authentication authentication, HttpServletResponse response) throws IOException {
         OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
         String email = oauth2User.getAttribute("email");
+        // JWTを生成して返す
+        String token = Jwts.builder()
+                .setSubject(oauth2User.getName())
+                .claim("email", oauth2User.getAttribute("email"))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 86400000))  // 有効期限を1日に設定
+                .signWith(SignatureAlgorithm.HS256, JWT_SECRET)
+                .compact();
+        Cookie jwtCookie = new Cookie("jwt_token",token); // jwt-tokenをcookieへ格納しておく
+        jwtCookie.setHttpOnly(true);     // JavaScriptからのアクセスを禁止
+        //jwtCookie.setSecure(true);       // HTTPS通信のみで送信(検証用にオフ)
+        jwtCookie.setPath("/");          // Cookieのパスを設定
+        jwtCookie.setMaxAge(86400);      // Cookieの有効期限（秒）
 
+        response.addCookie(jwtCookie);
+        response.sendRedirect("http://localhost:3000/");
+
+        return token;
     }
 }

--- a/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
@@ -1,0 +1,21 @@
+package myenglish.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.logging.Logger;
+
+/*認証成功時にJWT-Tokenを発行する*/
+@RestController
+public class OAuthSuccessController {
+    Logger logger = Logger.getLogger(OAuthSuccessController.class.getName());
+    @GetMapping("/loginsuccess")
+    public void loginSuccess(Authentication authentication) {
+        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        String email = oauth2User.getAttribute("email");
+
+    }
+}

--- a/MyEnglishServer/src/main/java/myenglish/security/WebMvcConfig.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/WebMvcConfig.java
@@ -1,0 +1,16 @@
+package myenglish.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")  // フロントエンドのURL
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowCredentials(true);  // Cookieの送信を許可
+    }
+}


### PR DESCRIPTION
手動で secret を適当に設定してもいいが、文字列の長さが暗号名通り指定されているのでなかなかめんどくさい
ツールに任せるのがベスト
https://jwtsecret.com/generate

脆弱性を生み出している個所については issue で起票して対応する