### PR TITLE
セッションでユーザー情報を管理できるよう機能を追加

### DIFF
--- a/MyEnglishServer/build.gradle
+++ b/MyEnglishServer/build.gradle
@@ -46,6 +46,17 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	// SESSION
+	//implementation 'io.projectreactor:reactor-core:3.5.10' // 最新の安定版を指定
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+	//implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.session:spring-session-data-redis'
+	//compileOnly 'org.projectlombok:lombok'
+	//developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	//annotationProcessor 'org.projectlombok:lombok'
+	//testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	//testImplementation 'io.projectreactor:reactor-test'
+	//testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/MyEnglishServer/src/main/java/myenglish/mapper/UserRootRepository.java
+++ b/MyEnglishServer/src/main/java/myenglish/mapper/UserRootRepository.java
@@ -10,7 +10,7 @@ public interface UserRootRepository {
 	int insert(MyEnglishUserEntity MyEnglishUserEntity);
 	/** id を 指定してユーザーを検索する **/
 	@Select("SELECT * FROM user_root WHERE user_id=#{userId}")
-	MyEnglishUserEntity selectById(@Param("user_id") Integer userId);
+	MyEnglishUserEntity selectById(@Param("userId") Integer userId);
 
 	/** email を 指定してユーザーを検索する **/
 	@Select("SELECT * FROM user_root WHERE email=#{email}")

--- a/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
@@ -9,8 +9,10 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import io.jsonwebtoken.Jwts;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Date;
 import java.util.logging.Logger;
 
@@ -18,6 +20,7 @@ import java.util.logging.Logger;
 @RestController
 public class OAuthSuccessController {
     private final UserServiceImpl userServiceImpl;
+    private final String baseUrl = "/websession/set";
     Logger logger = Logger.getLogger(OAuthSuccessController.class.getName());
     String JWT_SECRET = "e976d54cca0ba5f9744a6d4f8c3ee37c05081d204201740c469e6456e5f3eda3d6cd47bac68c9d05e5c2274baa623e8a977764c9aebd60ae4bd7ae4006dd0040f3ac25bf6f4a165b6f20c020529d3bece4ff60f9d444ba6bb59bfe2b47aa7eb63ee396fb005067ffb7f4bd2a1f2de66b966080a364433bda63b40e96ad15a38cf17f8dc36bb2a9d3517ef3ead06e364447755bf89a94eaecb63967669cca5b7bf317a1f075e1d97dc2348b928fd941debfd03adec6ca45fcb35e5039a4f486bdb63dd00ee2b2dccf76786f4925c59653b269308cec7c271f78ca21165e7bda8664353d8fee95dc4886f79d4fda139d9a4fe80afe9edc52356f13803e60533bf4";
 
@@ -42,6 +45,7 @@ public class OAuthSuccessController {
                 .setExpiration(new Date(System.currentTimeMillis() + 86400000))  // 有効期限を1日に設定
                 .signWith(SignatureAlgorithm.HS256, JWT_SECRET)
                 .compact();
+
         // JWTをCookieに登録する
         Cookie jwtCookie = new Cookie("jwt_token",token); // jwt-tokenをcookieへ格納しておく
         jwtCookie.setHttpOnly(true);     // JavaScriptからのアクセスを禁止
@@ -49,8 +53,15 @@ public class OAuthSuccessController {
         jwtCookie.setPath("/");          // Cookieのパスを設定
         jwtCookie.setMaxAge(86400);      // Cookieの有効期限（秒）
         response.addCookie(jwtCookie);
-        userServiceImpl.createUser(name,email);
-        // フロントエンドサーバのトップページへリダイレクトする
-        response.sendRedirect("http://localhost:3000/");
+
+        // ユーザーの作成
+        int userId = userServiceImpl.createUser(name,email);
+
+        // セッションにユーザー情報を登録しフロントエンドサーバへリダイレクトさせる
+        URI uri = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .queryParam("userid", "{userid}")
+                .build(userId);
+        response.sendRedirect(uri.toString());
     }
 }

--- a/MyEnglishServer/src/main/java/myenglish/service/user/UserService.java
+++ b/MyEnglishServer/src/main/java/myenglish/service/user/UserService.java
@@ -4,7 +4,7 @@ import myenglish.domain.MyEnglishUserEntity;
 
 public interface UserService {
     int createUser(String name,String email) throws Exception;
-    MyEnglishUserEntity getUser(String email);
+    MyEnglishUserEntity getUser(String email,int userId);
     // TODO: メールアドレス変更時のアカウント移管
     // TODO: アカウントの削除
 }

--- a/MyEnglishServer/src/main/java/myenglish/service/user/UserServiceImpl.java
+++ b/MyEnglishServer/src/main/java/myenglish/service/user/UserServiceImpl.java
@@ -13,18 +13,23 @@ public class UserServiceImpl implements UserService {
     @Override
     public int createUser(String name,String email){
         int userId = 0;
-        if(getUser(email) == null){
+        if(getUser(email,userId) == null){
             // ユーザーが存在しない場合は新しく作成する
             MyEnglishUserEntity myEnglishUserEntity =  new MyEnglishUserEntity(name,email);
             userRootRepository.insert(myEnglishUserEntity);
         }
-        userId = getUser(email).getUserId();
+        userId = getUser(email,userId).getUserId();
         return userId;
     }
 
     @Override
-    public MyEnglishUserEntity getUser(String email){
-        MyEnglishUserEntity myEnglishUserEntity =  userRootRepository.selectByEmail(email);;
+    public MyEnglishUserEntity getUser(String email,int userId){
+        MyEnglishUserEntity myEnglishUserEntity;
+        if(email == null){
+            myEnglishUserEntity = userRootRepository.selectById(userId);
+        }else{
+            myEnglishUserEntity = userRootRepository.selectByEmail(email);
+        }
         return myEnglishUserEntity;
     }
 

--- a/MyEnglishServer/src/main/java/myenglish/session/SessionConfig.java
+++ b/MyEnglishServer/src/main/java/myenglish/session/SessionConfig.java
@@ -1,0 +1,9 @@
+package myenglish.session;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.annotation.web.server.EnableRedisWebSession;
+
+@Configuration
+@EnableRedisWebSession()
+public class SessionConfig {
+}

--- a/MyEnglishServer/src/main/java/myenglish/session/SessionController.java
+++ b/MyEnglishServer/src/main/java/myenglish/session/SessionController.java
@@ -1,0 +1,49 @@
+package myenglish.session;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import myenglish.web.form.MyEnglishQuizTitleForm;
+import myenglish.web.form.UserSessionForm;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import org.springframework.web.server.WebSession;
+
+
+@Slf4j
+@RestController
+@AllArgsConstructor
+public class SessionController {
+    /**
+     * ユーザー情報のセッションを 更新/取得 するクラス
+     * Monoは単一の情報を返す , Fluxは複数の情報を返す
+     * */
+
+    @GetMapping("/websession")
+    public Mono<UserSessionForm> getSession (WebSession session){
+        // 値が何も存在しない場合に返すデフォルト値
+        session.getAttributes().putIfAbsent("userId", 0);
+        session.getAttributes().putIfAbsent("name", "anonymous");
+
+        // ユーザー情報をセッションから取得する
+        UserSessionForm userSessionForm = new UserSessionForm();
+        userSessionForm.setUserId((Integer) session.getAttributes().get("userId"));
+        userSessionForm.setName((String) session.getAttributes().get("name"));
+
+        return Mono.just(userSessionForm);
+    }
+
+    @GetMapping("/websession/set")
+    public void setSession (@RequestBody UserSessionForm userSessionForm, WebSession session){
+        int userId = userSessionForm.getUserId();
+        String name = userSessionForm.getName();
+
+        // セッションにユーザー情報を格納
+        session.getAttributes().put("userId", userId);
+        session.getAttributes().put("name", name);
+    }
+
+
+}

--- a/MyEnglishServer/src/main/java/myenglish/session/SessionController.java
+++ b/MyEnglishServer/src/main/java/myenglish/session/SessionController.java
@@ -1,48 +1,52 @@
 package myenglish.session;
 
-import lombok.AllArgsConstructor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import myenglish.web.form.MyEnglishQuizTitleForm;
-import myenglish.web.form.UserSessionForm;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
-import org.springframework.web.server.WebSession;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @Slf4j
-@RestController
-@AllArgsConstructor
+@Controller
+@RequiredArgsConstructor
 public class SessionController {
     /**
      * ユーザー情報のセッションを 更新/取得 するクラス
      * Monoは単一の情報を返す , Fluxは複数の情報を返す
      * */
+    private String redirectUrl = "http://localhost:3000"; //リダイレクト先のURL
+    private final HttpSession session;
 
-    @GetMapping("/websession")
-    public Mono<UserSessionForm> getSession (WebSession session){
-        // 値が何も存在しない場合に返すデフォルト値
-        session.getAttributes().putIfAbsent("userId", 0);
-        session.getAttributes().putIfAbsent("name", "anonymous");
-
-        // ユーザー情報をセッションから取得する
-        UserSessionForm userSessionForm = new UserSessionForm();
-        userSessionForm.setUserId((Integer) session.getAttributes().get("userId"));
-        userSessionForm.setName((String) session.getAttributes().get("name"));
-
-        return Mono.just(userSessionForm);
+    // セッション動作検証用 foo が keyのvalueを取得する
+    @GetMapping("/websession/get/test")
+    public void getSession (HttpServletRequest request){
+        // redisへのセッション処理
+        String returnData = (String) session.getAttribute("userId");
+        int userId = Integer.parseInt(returnData);
+        System.out.println("session data : " + userId);
+        // フロントエンドサーバへのリダイレクト処理
     }
 
-    @GetMapping("/websession/set")
-    public void setSession (@RequestBody UserSessionForm userSessionForm, WebSession session){
-        int userId = userSessionForm.getUserId();
-        String name = userSessionForm.getName();
 
+    // セッション動作検証用 foo(key) bar(value) をセッションへ格納する
+    @GetMapping("/websession/set/test")
+    public String setTestSession (HttpServletRequest request){
+        session.setAttribute("foo", "bar");
+        System.out.println("set-end");
+        // フロントエンドサーバへのリダイレクト処理
+        return "redirect:" + redirectUrl;
+
+    }
+
+    // 初回ログイン時にセッションへユーザーIDを登録する
+    @GetMapping("/websession/set")
+    public String setSession (@RequestParam("userid") String userId){
         // セッションにユーザー情報を格納
-        session.getAttributes().put("userId", userId);
-        session.getAttributes().put("name", name);
+        session.setAttribute("userId", userId);
+        return "redirect:" + redirectUrl;
     }
 
 

--- a/MyEnglishServer/src/main/java/myenglish/web/form/UserSessionForm.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/form/UserSessionForm.java
@@ -1,0 +1,25 @@
+package myenglish.web.form;
+
+import java.io.Serializable;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+
+public class UserSessionForm implements Serializable {
+
+    private String sessionId;
+
+    private String creationTime;
+
+    private String lastAccessedTime;
+
+    private String maxIdleTime;
+
+    private Integer userId;
+
+    private String name;
+
+}

--- a/MyEnglishServer/src/main/java/myenglish/web/quiz/MyEnglishQuizControllerRestAPI.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/quiz/MyEnglishQuizControllerRestAPI.java
@@ -23,8 +23,6 @@ public class MyEnglishQuizControllerRestAPI {
 	private final QuizServiceImpl quizService;
 	
 	/** クイズのトップ画面 **/
-	@CrossOrigin
-	(origins = "http://localhost:3000")
 	@GetMapping("")
 	public List<MyEnglishQuizTitleEntity> entryQuiz() {
 		/** MockUserData **/
@@ -41,8 +39,6 @@ public class MyEnglishQuizControllerRestAPI {
 	}
 	
 	/** クイズタイトルをDBへ保存 **/
-	@CrossOrigin
-	(origins = "http://localhost:3000")
 	@PostMapping("/save")
 	public void saveQuizTitle(@RequestBody MyEnglishQuizTitleForm form) {
 		// TODO:エラーをハンドリングする
@@ -53,8 +49,6 @@ public class MyEnglishQuizControllerRestAPI {
 
 	
 	// クイズ更新画面
-	@CrossOrigin
-	(origins = "http://localhost:3000")
 	@PostMapping("/update")
 	public void quizForm(@RequestBody MyEnglishQuizTitleForm form) {
 			// TODO:エラーをハンドリングする
@@ -64,8 +58,6 @@ public class MyEnglishQuizControllerRestAPI {
 		}	
 	
 	/** クイズ削除 **/
-	@CrossOrigin
-	(origins = "http://localhost:3000")
 	@PostMapping("/delete")
 	public void quizTitleDelete(@RequestBody MyEnglishQuizTitleForm form) {
 		int id = form.getQuestionTitleId();

--- a/MyEnglishServer/src/main/java/myenglish/web/quiz/MyEnglishQuizControllerRestAPI.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/quiz/MyEnglishQuizControllerRestAPI.java
@@ -2,6 +2,8 @@ package myenglish.web.quiz;
 
 import java.util.List;
 
+import jakarta.servlet.http.HttpSession;
+import myenglish.service.user.UserServiceImpl;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,14 +23,16 @@ import myenglish.web.form.MyEnglishQuizTitleForm;
 @RestController
 public class MyEnglishQuizControllerRestAPI {
 	private final QuizServiceImpl quizService;
-	
+	private final UserServiceImpl userService;
 	/** クイズのトップ画面 **/
 	@GetMapping("")
-	public List<MyEnglishQuizTitleEntity> entryQuiz() {
-		/** MockUserData **/
-		MyEnglishUserEntity userProperty = new MyEnglishUserEntity();
-		userProperty.setUserId(1);
-		
+	public List<MyEnglishQuizTitleEntity> entryQuiz(HttpSession session) {
+		// セッションからユーザーIDを取得する
+		int userId = Integer.parseInt((String) session.getAttribute("userId"));
+		// userIdからユーザー情報を取得する
+		MyEnglishUserEntity userProperty = userService.getUser(null, userId);
+		userProperty.setUserId(userId);
+
 		// 問題のタイトルを取得
 		List<MyEnglishQuizTitleEntity> questionTitles = quizService.getQuestionTitle(userProperty);
 		boolean isGetTitleNull = questionTitles.stream().anyMatch(title -> title == null);
@@ -40,21 +44,29 @@ public class MyEnglishQuizControllerRestAPI {
 	
 	/** クイズタイトルをDBへ保存 **/
 	@PostMapping("/save")
-	public void saveQuizTitle(@RequestBody MyEnglishQuizTitleForm form) {
+	public void saveQuizTitle(@RequestBody MyEnglishQuizTitleForm form,HttpSession session) {
 		// TODO:エラーをハンドリングする
 		// 入力されたタイトルフォームを変換しDBに登録
 		MyEnglishQuizTitleEntity titleEntity = MyEnglishQuizTitleFormHelper.convertToEntity(form);
+		// セッションからユーザーIDを取得する
+		int userId = Integer.parseInt((String) session.getAttribute("userId"));
+
+		titleEntity.setOwnerUserId(userId);
 		quizService.insertQuestionTitle(titleEntity);
 	}
 
 	
 	// クイズ更新画面
 	@PostMapping("/update")
-	public void quizForm(@RequestBody MyEnglishQuizTitleForm form) {
-			// TODO:エラーをハンドリングする
-			/** 編集した内容でアップデート **/	
-			MyEnglishQuizTitleEntity titleEntity = MyEnglishQuizTitleFormHelper.convertToEntity(form);
-			quizService.updateQuestion(titleEntity);
+	public void quizForm(@RequestBody MyEnglishQuizTitleForm form,HttpSession session) {
+		// TODO:エラーをハンドリングする
+		/** 編集した内容でアップデート **/
+		// セッションからユーザーIDを取得する
+		int userId = Integer.parseInt((String) session.getAttribute("userId"));
+
+		MyEnglishQuizTitleEntity titleEntity = MyEnglishQuizTitleFormHelper.convertToEntity(form);
+		titleEntity.setOwnerUserId(userId);
+		quizService.updateQuestion(titleEntity);
 		}	
 	
 	/** クイズ削除 **/

--- a/MyEnglishServer/src/main/java/myenglish/web/quizdetails/MyEnglishQuizDetailsRestAPI.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/quizdetails/MyEnglishQuizDetailsRestAPI.java
@@ -3,6 +3,7 @@ package myenglish.web.quizdetails;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.servlet.http.HttpSession;
 import myenglish.helper.MyEnglishQuizAnswerFormHelper;
 import myenglish.helper.MyEnglishQuizDetailsFormHelper;
 import org.springframework.ui.Model;
@@ -41,10 +42,11 @@ public class MyEnglishQuizDetailsRestAPI{
 	@CrossOrigin
 	(origins = "http://localhost:3000")
 	@PostMapping("/")
-	public List<MyEnglishQuizDetailsEntity> quizdetails(@RequestBody MyEnglishQuizTitleForm quiestionTitle) {
-		
+	public List<MyEnglishQuizDetailsEntity> quizdetails(@RequestBody MyEnglishQuizTitleForm quiestionTitle, HttpSession session) {
+		// セッションからユーザーIDを取得する
+		int userId = Integer.parseInt((String) session.getAttribute("userId"));
 		MyEnglishQuizTitleEntity quiestionTitleEntity = MyEnglishQuizTitleFormHelper.convertToEntity(quiestionTitle);
-		
+		quiestionTitleEntity.setOwnerUserId(userId);
 		/** クイズタイトルに該当の問題情報を取得する **/
 		List<MyEnglishQuizDetailsEntity> quizDetails = 
 				quizService.getQuestionDetails(quiestionTitleEntity);

--- a/MyEnglishServer/src/main/java/myenglish/web/takequiz/MyEnglishTakeQuizRestAPI.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/takequiz/MyEnglishTakeQuizRestAPI.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,6 +31,7 @@ public class MyEnglishTakeQuizRestAPI {
 	(origins = "http://localhost:3000")
 	@PostMapping("/")
 	public List<MyEnglishQuizDetailsWrapperForm> takeQuiz(@RequestBody  MyEnglishQuizTitleForm questionTitle) {
+
 		// 対象の問題と答えをWrapperへ格納
 		MyEnglishQuizTitleEntity myEnglishQuestionTitleEntity = new MyEnglishQuizTitleEntity();
 		myEnglishQuestionTitleEntity.setQuestionTitleId(questionTitle.getQuestionTitleId());

--- a/MyEnglishServer/src/main/resources/application.properties
+++ b/MyEnglishServer/src/main/resources/application.properties
@@ -8,12 +8,17 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=classpath:data.sql
+# Redis
+spring.data.redis.host=127.0.0.1
+spring.data.redis.port=6379
+spring.data.redis.password=null
+
 # Log
 logging.level.myenglish = DEBUG
 # oauth
 spring.security.oauth2.client.registration.google.client-id: ${G_AUTH_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret: ${G_AUTH_SECRET}
 # session
-server.servlet.session.timeout=3600
-spring.session.redis.flush-mode=on_save
-spring.session.redis.namespace=spring:session
+#server.servlet.session.timeout=3600
+#spring.session.redis.flush-mode=on_save
+#spring.session.redis.namespace=spring:session

--- a/MyEnglishServer/src/main/resources/application.properties
+++ b/MyEnglishServer/src/main/resources/application.properties
@@ -10,5 +10,10 @@ spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=classpath:data.sql
 # Log
 logging.level.myenglish = DEBUG
+# oauth
 spring.security.oauth2.client.registration.google.client-id: ${G_AUTH_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret: ${G_AUTH_SECRET}
+# session
+server.servlet.session.timeout=3600
+spring.session.redis.flush-mode=on_save
+spring.session.redis.namespace=spring:session


### PR DESCRIPTION
- 参考
  - https://qiita.com/yu-tarrrr/items/07eabf48235d04331f9e
  - https://spring.pleiades.io/spring-framework/reference/web/webmvc/mvc-uri-building.html 

- セッションIDを発行してるのはおそらく、oauthで利用している google  
  - セッションIDを削除してログインしても再度同様のSESSIONIDが発行される
- アクセストークンは自分で発行 (JWT)  
- セッションの捜査はすべてバックエンドで行いフロントエンドでは触らないようにした
  - セッションを使う場合は localstorage を利用し、書き換えられても支障のない値で利用する  