### PR TITLE
restcontrolleradvice として ハンドリングされるように修正

### DIFF
--- a/MyEnglishServer/src/main/java/myenglish/web/exception/ExceptionController.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/exception/ExceptionController.java
@@ -4,9 +4,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 
-@RestController
+@RestControllerAdvice
 public class ExceptionController {
     @ExceptionHandler(InvalidRequestException.class)
     public ProblemDetail InvalidRequestExceptionHandler(InvalidRequestException e) {


### PR DESCRIPTION
### @RestControllerAdvice とは

`@ControllerAdvice` と `@ResponseBody` が組み合わされた アノテーション. 

### ExceptionHandler の 動かし方

ExceptionHandler は 同クラス内で発生したExceptionをハンドリングし、設定したオブジェクトを返す. 
そのため ExceptionHandlerを動かしたい場合は **同じクラスに記述** するか **RestControllerAdvice** で 全体のクラス共通のExceptionとすることで動く
