### PR TITLE
ドメインを /webを基本とする。/loginだけはそのまま

### DIFF
--- a/MyEnglishServer/src/main/java/myenglish/security/OAuth2LoginSecurityConfig.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/OAuth2LoginSecurityConfig.java
@@ -22,7 +22,8 @@ public class OAuth2LoginSecurityConfig {
                 .csrf(csrf -> csrf.disable()) // CSRFを無効化
                 .oauth2Login(withDefaults())  // 認証設定にデフォルトの設定を利用する (applicatin.yml)
                 .oauth2Login(customizer -> customizer
-                        .defaultSuccessUrl("/loginsuccess",true)); // ログイン成功後にログイン成功リダイレクト先に遷移。trueでいつでも有効にする。
+                        .defaultSuccessUrl("/web/loginsuccess",true)
+                ); // ログイン成功後にログイン成功リダイレクト先に遷移。trueでいつでも有効にする。
 
         return http.build();
     }

--- a/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
+++ b/MyEnglishServer/src/main/java/myenglish/security/OAuthSuccessController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import io.jsonwebtoken.Jwts;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -21,6 +22,7 @@ import java.util.Date;
 import java.util.logging.Logger;
 
 /*認証成功時にJWT-Tokenを発行する*/
+@RequestMapping("/web")
 @RestController
 public class OAuthSuccessController {
     private final UserServiceImpl userServiceImpl;
@@ -63,7 +65,7 @@ public class OAuthSuccessController {
         int userId = userServiceImpl.createUser(name,email);
 
         // セッションにユーザー情報を登録しフロントエンドサーバへリダイレクトさせる
-        String baseUrl = "/websession/set";
+        String baseUrl = "/web/websession/set";
         URI uri = UriComponentsBuilder
                 .fromUriString(baseUrl)
                 .queryParam("userid", "{userid}")

--- a/MyEnglishServer/src/main/java/myenglish/session/SessionController.java
+++ b/MyEnglishServer/src/main/java/myenglish/session/SessionController.java
@@ -3,15 +3,15 @@ package myenglish.session;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 
-@Slf4j
 @Controller
+@RequestMapping(value="/web")
 @RequiredArgsConstructor
 public class SessionController {
     /**

--- a/MyEnglishServer/src/main/java/myenglish/web/LoginConfirmController.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/LoginConfirmController.java
@@ -5,10 +5,10 @@ import lombok.RequiredArgsConstructor;
 import myenglish.service.user.UserService;
 import myenglish.web.exception.UserNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Optional;
-
+@RequestMapping(value="/web")
 @RequiredArgsConstructor
 @RestController
 public class LoginConfirmController {

--- a/MyEnglishServer/src/main/java/myenglish/web/exception/ExceptionController.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/exception/ExceptionController.java
@@ -3,7 +3,6 @@ package myenglish.web.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 

--- a/MyEnglishServer/src/main/java/myenglish/web/quiz/QuestionRestAPI.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/quiz/QuestionRestAPI.java
@@ -7,7 +7,6 @@ import myenglish.domain.dto.QuestionTitleResponse;
 import myenglish.service.quiz.title.QuizTitleServiceImpl;
 
 import myenglish.web.exception.InvalidRequestException;
-import myenglish.web.exception.UserNotFoundException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import myenglish.web.form.QuestionTitleForm;
 
-@RequestMapping(value="/quizrest")
+@RequestMapping(value="/web/quizrest")
 @RequiredArgsConstructor
 @RestController
 public class QuestionRestAPI {
@@ -32,7 +31,7 @@ public class QuestionRestAPI {
 	public List<QuestionTitleResponse> entryQuiz(HttpSession session) {
 			return quizTitleService.getQuestionTitle(session);
 	}
-	
+	// TODO: ドメインを他と統一するべし
 	/** クイズタイトルをDBへ保存 **/
 	@PostMapping("/save")
 	public void saveQuizTitle(@RequestBody @Validated QuestionTitleForm form , BindingResult bindingResult, HttpSession session) {

--- a/MyEnglishServer/src/main/java/myenglish/web/quizdetails/QuestionDetailsRestAPI.java
+++ b/MyEnglishServer/src/main/java/myenglish/web/quizdetails/QuestionDetailsRestAPI.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
-@RequestMapping("quizdetailsrest")
+@RequestMapping("/web/quizdetailsrest")
 @RequiredArgsConstructor
 @RestController
 public class QuestionDetailsRestAPI {


### PR DESCRIPTION
以下のようログインドメインを設定するとリダイレクトが複数回走って、many redirect エラーが永遠と表示され続けてしまうので、loginは一旦 そのままにする
```java
                .oauth2Login(customizer -> customizer
                        .loginPage("/login")
                        .defaultSuccessUrl("/web/loginsuccess",true)
                ); // ログイン成功後にログイン成功リダイレクト先に遷移。trueでいつでも有効にする。
```
